### PR TITLE
provide script for injecting rxdm sidecar into kubenetes job workload

### DIFF
--- a/a3/examples/gke/main.tf
+++ b/a3/examples/gke/main.tf
@@ -4,7 +4,7 @@ variable "resource_prefix" {}
 variable "region" {}
 
 module "a3-gke" {
-  source = "github.com/GoogleCloudPlatform/ai-infra-cluster-provisioning//a3/terraform/modules/cluster/gke"
+  source = "../../terraform/modules/cluster/gke"#github.com/GoogleCloudPlatform/ai-infra-cluster-provisioning//a3/terraform/modules/cluster/gke"
 
   node_pools      = var.node_pools
   project_id      = var.project_id

--- a/a3/examples/gke/main.tf
+++ b/a3/examples/gke/main.tf
@@ -2,12 +2,16 @@ variable "node_pools" {}
 variable "project_id" {}
 variable "resource_prefix" {}
 variable "region" {}
+variable "user_workload_path" {
+  default = "./sample-tcpx-workload/sample-job.yaml"
+}
 
 module "a3-gke" {
   source = "../../terraform/modules/cluster/gke"#github.com/GoogleCloudPlatform/ai-infra-cluster-provisioning//a3/terraform/modules/cluster/gke"
 
-  node_pools      = var.node_pools
-  project_id      = var.project_id
-  resource_prefix = var.resource_prefix
-  region          = var.region
+  node_pools         = var.node_pools
+  project_id         = var.project_id
+  resource_prefix    = var.resource_prefix
+  region             = var.region
+  user_workload_path = var.user_workload_path
 }

--- a/a3/examples/gke/sample-tcpx-workload/sample-configmap.yaml
+++ b/a3/examples/gke/sample-tcpx-workload/sample-configmap.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nccl-configmap
+data:
+  allgather.sh: |-
+    #!/bin/bash
+    for script in /configs/*; do
+      name=$(basename $script)
+      cp $script "/scripts/$name"
+      chmod +x "/scripts/$name"
+    done
+    /scripts/init_ssh.sh ${@};
+    pushd /scripts;
+    /scripts/gen_hostfiles.sh ${@};
+    popd;
+    /scripts/run-allgather.sh 8 eth1,eth2,eth3,eth4 1M 512M ${#};
+  run-nccl.sh: |-
+    #!/bin/bash
+    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    source "${SCRIPT_DIR}"/unix_client_prefix_selection.sh
+    benchmark=$1
+    ld_library_path_override=$2
+    gpu_per_node=$3
+    socket_ifnames=$4
+    data_b=$5
+    data_e=$6
+    nhosts=2
+    if ! [[ -z "$7" ]]; then nhosts=$7; fi
+    LD_LIBRARY_PATH=${ld_library_path_override} \
+    mpirun --mca btl tcp,self --mca btl_tcp_if_include eth0 --allow-run-as-root \
+    --mca orte_base_help_aggregate 0 \
+    --mca pcompress_base_silence_warning 1 \
+    -np $(( gpu_per_node * "${nhosts}" )) \
+    --hostfile "${SCRIPT_DIR}/hostfiles${nhosts}/hostfile${gpu_per_node}" \
+    -x LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+    -x NCCL_GPUDIRECTTCPX_FORCE_ACK=0 \
+    -x NCCL_GPUDIRECTTCPX_TX_COMPLETION_NANOSLEEP=1000 \
+    -x NCCL_SOCKET_IFNAME=eth0 \
+    -x NCCL_DYNAMIC_CHUNK_SIZE=524288 \
+    -x NCCL_P2P_NET_CHUNKSIZE=524288 \
+    -x NCCL_P2P_PCI_CHUNKSIZE=524288 \
+    -x NCCL_P2P_NVL_CHUNKSIZE=1048576 \
+    -x NCCL_GPUDIRECTTCPX_TX_BINDINGS="eth1:8-21,112-125;eth2:8-21,112-125;eth3:60-73,164-177;eth4:60-73,164-177" \
+    -x NCCL_GPUDIRECTTCPX_RX_BINDINGS="eth1:22-35,124-139;eth2:22-35,124-139;eth3:74-87,178-191;eth4:74-87,178-191" \
+    -x NCCL_NSOCKS_PERTHREAD=4 \
+    -x NCCL_SOCKET_NTHREADS=1 \
+    -x NCCL_MAX_NCHANNELS=8 \
+    -x NCCL_MIN_NCHANNELS=8 \
+    -x NCCL_BUFFSIZE=4194304 \
+    -x NCCL_DEBUG=INFO -x NCCL_DEBUG_SUBSYS=ENV \
+    -x NCCL_GPUDIRECTTCPX_SOCKET_IFNAME=eth1,eth2,eth3,eth4 \
+    -x NCCL_GPUDIRECTTCPX_CTRL_DEV=eth0 \
+    -x NCCL_GPUDIRECTTCPX_PROGRAM_FLOW_STEERING_WAIT_MICROS=500000 \
+    -x NCCL_CROSS_NIC=0 \
+    -x NCCL_ALGO=Ring \
+    -x NCCL_PROTO=Simple \
+    -x NCCL_NET_GDR_LEVEL=PIX \
+    -x NCCL_P2P_PXN_LEVEL=0 \
+    taskset -c 0-7,104-111,52-59,156-163 \
+    /third_party/nccl-tests-mpi/build/"${benchmark}" \
+    -b "${data_b}" -e "${data_e}" -f 2 -g 1 -w 5 --iters 100 -c 0 2>&1 \
+    | tee "a_${nhosts}_${gpu_per_node}_${socket_ifnames}.txt"

--- a/a3/examples/gke/sample-tcpx-workload/sample-job.yaml
+++ b/a3/examples/gke/sample-tcpx-workload/sample-job.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-sample-job
+spec:
+  parallelism: 2
+  completions: 2
+  completionMode: Indexed
+  template:
+    spec:
+      containers:
+      - name: nccl-test
+        image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx-dev:v3.1.9
+        imagePullPolicy: Always
+        command:
+          - /bin/sh
+          - -c
+          - |
+            service ssh restart;
+            sleep infinity;
+        env:
+          - name: LD_LIBRARY_PATH
+            value: /usr/local/nvidia/lib64
+        volumeMounts:
+          - name: config-volume
+            mountPath: /configs
+        resources:
+          limits:
+            nvidia.com/gpu: 8
+      volumes:
+        - name: config-volume
+          configMap:
+            name: nccl-configmap
+            defaultMode: 0777
+      restartPolicy: Never
+  backoffLimit: 0

--- a/a3/terraform/modules/cluster/gke/kubectl-apply/aiinfra-ksa.tf
+++ b/a3/terraform/modules/cluster/gke/kubectl-apply/aiinfra-ksa.tf
@@ -136,8 +136,8 @@ resource "kubectl_manifest" "installer_network_param_set" {
   metadata:
     name: vpc${count.index}
   spec:
-    vpc: chdu-a3-tcpx-gpu-${count.index}
-    vpcSubnet: chdu-a3-tcpx-gpu-${count.index}
+    vpc: ${resource_prefix}-gpu-${count.index}
+    vpcSubnet: ${resource_prefix}-gpu-${count.index}
     deviceMode: NetDevice
   YAML
   wait_for_rollout = false

--- a/a3/terraform/modules/cluster/gke/kubectl-apply/aiinfra-ksa.tf
+++ b/a3/terraform/modules/cluster/gke/kubectl-apply/aiinfra-ksa.tf
@@ -136,8 +136,8 @@ resource "kubectl_manifest" "installer_network_param_set" {
   metadata:
     name: vpc${count.index}
   spec:
-    vpc: ${resource_prefix}-gpu-${count.index}
-    vpcSubnet: ${resource_prefix}-gpu-${count.index}
+    vpc: ${var.resource_prefix}-gpu-${count.index}
+    vpcSubnet: ${var.resource_prefix}-gpu-${count.index}
     deviceMode: NetDevice
   YAML
   wait_for_rollout = false

--- a/a3/terraform/modules/cluster/gke/kubectl-apply/aiinfra-ksa.tf
+++ b/a3/terraform/modules/cluster/gke/kubectl-apply/aiinfra-ksa.tf
@@ -90,3 +90,57 @@ resource "kubectl_manifest" "installer_daemonsets" {
 
   depends_on = [resource.google_service_account_iam_binding.default-workload-identity]
 }
+
+resource "kubectl_manifest" "installer_workload" {
+  for_each = var.enable ? var.manifest_path : {}
+
+  yaml_body        = fileexists(var.manifest_path[each.key]) ? file(var.manifest_path[each.key]) : <<YAML
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: place-holder-configmap
+data:
+  placeholder: "true"
+YAML
+  wait_for_rollout = false
+
+  depends_on = [resource.google_service_account_iam_binding.default-workload-identity]
+}
+
+resource "kubectl_manifest" "installer_network" {
+  count = var.enable ? 4 : 0
+
+  yaml_body        = <<YAML
+  apiVersion: networking.gke.io/v1
+  kind: Network
+  metadata:
+    name: vpc${count.index}
+  spec:
+    parametersRef:
+      group: networking.gke.io
+      kind: GKENetworkParamSet
+      name: vpc${count.index}
+    type: Device
+  YAML
+  wait_for_rollout = false
+
+  depends_on = [resource.google_service_account_iam_binding.default-workload-identity]
+}
+
+resource "kubectl_manifest" "installer_network_param_set" {
+  count = var.enable ? 4 : 0
+
+  yaml_body        = <<YAML
+  apiVersion: networking.gke.io/v1
+  kind: GKENetworkParamSet
+  metadata:
+    name: vpc${count.index}
+  spec:
+    vpc: chdu-a3-tcpx-gpu-${count.index}
+    vpcSubnet: chdu-a3-tcpx-gpu-${count.index}
+    deviceMode: NetDevice
+  YAML
+  wait_for_rollout = false
+
+  depends_on = [resource.google_service_account_iam_binding.default-workload-identity]
+}

--- a/a3/terraform/modules/cluster/gke/kubectl-apply/variables.tf
+++ b/a3/terraform/modules/cluster/gke/kubectl-apply/variables.tf
@@ -66,6 +66,17 @@ variable "gcp_sa" {
   nullable    = false
 }
 
+variable "manifest_path" {
+  description = "Path to the manifest file to install with kubectl apply"
+  type        = map(string)
+  nullable    = false
+
+  validation {
+    condition     = length(var.manifest_path) != 0
+    error_message = "must specify at least one manifest path"
+  }
+}
+
 variable "project_id" {
   description = "Name of the project to use for instantiating clusters."
   type        = string

--- a/a3/terraform/modules/cluster/gke/kubectl-apply/variables.tf
+++ b/a3/terraform/modules/cluster/gke/kubectl-apply/variables.tf
@@ -77,6 +77,12 @@ variable "manifest_path" {
   }
 }
 
+variable "resource_prefix" {
+  description = "Arbitrary string with which all names of newly created resources will be prefixed."
+  type        = string
+  nullable    = false
+}
+
 variable "project_id" {
   description = "Name of the project to use for instantiating clusters."
   type        = string

--- a/a3/terraform/modules/cluster/gke/main.tf
+++ b/a3/terraform/modules/cluster/gke/main.tf
@@ -302,13 +302,20 @@ resource "google_project_iam_member" "node_service_account_monitoringViewer" {
   member  = "serviceAccount:${local.node_service_account}"
 }
 
+resource "null_resource" "install_dependencies" {
+  provisioner "local-exec" {
+      command = "pip3 install pyyaml argparse"
+  }
+}
+
 resource "null_resource" "enable_tcpx_in_workload" {
   triggers = {
     always_run = "${timestamp()}"
   }
   provisioner "local-exec" {
-      command = "python ../../../scripts/enable_tcpx_in_workload.py --file ${var.user_workload_path} --nccl v3.1.9 --rxdm v2.0.12"
+      command = "python3 ../../../scripts/enable_tcpx_in_workload.py --file ${var.user_workload_path} --nccl v3.1.9 --rxdm v2.0.12"
   }
+  depends_on = [ null_resource.install_dependencies ]
 }
 
 module "kubectl-apply" {

--- a/a3/terraform/modules/cluster/gke/main.tf
+++ b/a3/terraform/modules/cluster/gke/main.tf
@@ -337,4 +337,5 @@ module "kubectl-apply" {
   ksa        = var.ksa
   gcp_sa     = local.node_service_account
   project_id = var.project_id
+  resource_prefix = var.resource_prefix
 }

--- a/a3/terraform/modules/cluster/gke/variables.tf
+++ b/a3/terraform/modules/cluster/gke/variables.tf
@@ -166,3 +166,9 @@ variable "resource_prefix" {
   type        = string
   nullable    = false
 }
+
+variable "user_workload_path" {
+  description = "The path to the user workload, this should point to the kubernetes job manifest that user want to have the TCPX sidecar injected."
+  type        = string
+  default     = "./sample-tcpx-workload/sample-job.yaml"
+}

--- a/scripts/enable_tcpx_in_workload.py
+++ b/scripts/enable_tcpx_in_workload.py
@@ -53,7 +53,7 @@ def main():
     updated_job = str(yaml.safe_dump(job_manifest, default_flow_style=False, width=1000, default_style="|", sort_keys=False)).replace("|-", "")
 
     new_file_name = args.file.replace(".yaml", "-tcpx.yaml")
-    with open("./"+new_file_name, "w", encoding="utf-8") as file:
+    with open(new_file_name, "w", encoding="utf-8") as file:
         file.write(updated_job)
 
     # Step 7: Provide instructions to the user

--- a/scripts/enable_tcpx_in_workload.py
+++ b/scripts/enable_tcpx_in_workload.py
@@ -1,0 +1,174 @@
+import yaml
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description="TCPX Job Manifest Generator")
+    parser.add_argument("-f", "--file", required=True, help="Path to your job template YAML file")
+    parser.add_argument("-n", "--nccl", required=True, help="NCCL plugin version")
+    parser.add_argument("-r", "--rxdm", required=True, help="RxDM version")
+    # parser.add_argument("-y", "--yes", action="store_true", help="Auto-consent to continue even if version combination is not listed (use with caution)")
+
+    args = parser.parse_args()
+
+    # Step 1: Get the YAML file from the user
+    if not args.file:
+        args.file = input("Please provide the path to your job template YAML file: ")
+        
+    # Step 2: Open the compatibility list link
+    # compatibility_link = "https://docs.google.com/document/d/1D5umT4-WDuNnYf3ieQ5SfLdmvGRPBQGLB662udzwz8I"  # Replace with the actual link
+    # print(f"Please check this link for supported version combinations for NCCL plugin and RxDM: {compatibility_link}")
+
+    # Step 3: Get user consent
+    # if not args.yes:  # Don't ask for consent if -y is provided
+    #     compatibility_link = "https://docs.google.com/document/d/1D5umT4-WDuNnYf3ieQ5SfLdmvGRPBQGLB662udzwz8I"
+    #     print(f"Please check this link for supported version combinations for NCCL plugin and RxDM: {compatibility_link}")
+    #     consent = input("Version combination not listed in the link might impact performance, please consent to continue (yes/no): ")
+    #     if consent.lower() != "yes" and consent.lower() != "y":
+    #         print("Exiting the script. Please choose supported versions.")
+    #         return
+
+    # Step 4: Get component versions from user
+    if not args.nccl:
+        args.nccl = input("Enter the NCCL plugin version: ")
+    if not args.rxdm:
+        args.rxdm = input("Enter the RxDM version: ")
+
+    # Step 5: Load and modify the YAML
+    with open(args.file, "r") as file:
+        job_manifest = yaml.safe_load(file)
+
+    # Update annotations
+    add_annotations(job_manifest)
+
+    # # Update volumes
+    add_volumes(job_manifest)
+
+    # # Add tcpx-daemon container
+    add_tcpx_daemon_container(job_manifest, args.rxdm)
+
+    # # Update environment variables and volumeMounts for GPU containers
+    update_gpu_containers(job_manifest)
+
+    # Step 6: Generate the new YAML file
+    updated_job = str(yaml.safe_dump(job_manifest, default_flow_style=False, width=1000, default_style="|", sort_keys=False)).replace("|-", "")
+
+    new_file_name = args.file.replace(".yaml", "-tcpx.yaml")
+    with open("./"+new_file_name, "w", encoding="utf-8") as file:
+        file.write(updated_job)
+
+    # Step 7: Provide instructions to the user
+    print("\nPlease follow the below steps to complete enabling TCPX:")
+    print("1. Deploy NCCL plugin component if it haven't been deploy (update version):")
+    print("   kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/gpudirect-tcpx/nccl-tcpx-installer.yaml")
+    print("   (Replace 'nccl-tcpx-installer.yaml' with the correct version)")
+    print("2. Deploy NRI device injector plugin if it haven't been deploy :")
+    print("   kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nri_device_injector/nri-device-injector.yaml")
+    print("3. Deploy your workload with the updated manifest:", new_file_name)
+    print("4. Verify your workload is working as expected")
+
+def add_annotations(job_manifest):
+    annotations = {
+        'devices.gke.io/container.tcpx-daemon':"""|+
+- path: /dev/nvidia0
+- path: /dev/nvidia1
+- path: /dev/nvidia2
+- path: /dev/nvidia3
+- path: /dev/nvidia4
+- path: /dev/nvidia5
+- path: /dev/nvidia6
+- path: /dev/nvidia7
+- path: /dev/nvidiactl
+- path: /dev/nvidia-uvm""",
+        "networking.gke.io/default-interface": "eth0",
+        "networking.gke.io/interfaces":"""|
+[
+    {"interfaceName":"eth0","network":"default"},
+    {"interfaceName":"eth1","network":"vpc0"},
+    {"interfaceName":"eth2","network":"vpc1"},
+    {"interfaceName":"eth3","network":"vpc2"},
+    {"interfaceName":"eth4","network":"vpc3"}
+]""",
+    }
+
+    # Create path if it doesn't exist
+    job_manifest.setdefault("spec", {}).setdefault("template", {}).setdefault("metadata", {})
+
+    # Add/update annotations
+    pod_template_spec = job_manifest["spec"]["template"]["metadata"]
+    if "annotations" in pod_template_spec:
+        pod_template_spec["annotations"].update(annotations)
+    else:
+        pod_template_spec["annotations"] = annotations
+
+def add_volumes(job_manifest):
+    volumes = [
+        {"name": "libraries", "hostPath": {"path": "/home/kubernetes/bin/nvidia/lib64"}},
+        {"name": "tcpx-socket", "emptyDir": {}},
+        {"name": "sys", "hostPath": {"path": "/sys"}},
+        {"name": "proc-sys", "hostPath": {"path": "/proc/sys"}},
+    ]
+
+    # Create path if it doesn't exist
+    job_manifest.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+
+    # Add volumes
+    pod_spec = job_manifest["spec"]["template"]["spec"]
+    if "volumes" in pod_spec:
+        pod_spec["volumes"].extend(volumes)
+    else:
+        pod_spec["volumes"] = volumes
+
+
+def add_tcpx_daemon_container(job_template, rxdm_version):
+    tcpx_daemon_container = {
+        "name": "tcpx-daemon",
+        "image": f"us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:{rxdm_version}",   # Use provided RxDM version
+        "imagePullPolicy": "Always",
+        "command": 
+        """- /tcpgpudmarxd/build/app/tcpgpudmarxd
+- --gpu_nic_preset
+- a3vm
+- --gpu_shmem_type
+- fd
+- --uds_path
+- /run/tcpx
+- --setup_param
+- \\\"--verbose 128 2 0 \\\"""",
+        "securityContext": {
+            "capabilities": {"add": ["NET_ADMIN"]}
+        },
+        "volumeMounts": [
+            {"name": "libraries", "mountPath": "/usr/local/nvidia/lib64"},
+            {"name": "tcpx-socket", "mountPath": "/run/tcpx"},
+            {"name": "sys", "mountPath": "/hostsysfs"},
+            {"name": "proc-sys", "mountPath": "/hostprocsysfs"},
+        ],
+        "env": [{"name": "LD_LIBRARY_PATH", "value": "/usr/local/nvidia/lib64"}],
+    }
+
+    # Create path if it doesn't exist
+    job_template.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+
+    # Add container
+    pod_spec = job_template["spec"]["template"]["spec"]
+    pod_spec.setdefault("containers", []).insert(0, tcpx_daemon_container)
+
+def update_gpu_containers(job_manifest):
+    env_vars = [{"name": "LD_LIBRARY_PATH", "value": "/usr/local/nvidia/lib64"}]
+    volume_mounts = [
+        {"name": "tcpx-socket", "mountPath": "/tmp"},
+        {"name": "libraries", "mountPath": "/usr/local/nvidia/lib64"},
+    ]
+
+    pod_spec = job_manifest.get("spec", {}).get("template", {}).get("spec", {})
+    for container in pod_spec.get("containers", []):
+        # Create path if it doesn't exist
+        container.setdefault("env", [])
+        container.setdefault("volumeMounts", [])
+        if container.get("resources", {}).get("limits", {}).get("nvidia.com/gpu", 0) > 0:
+            container["env"].extend(env_vars)
+            container["volumeMounts"].extend(volume_mounts)
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Improve TCPX/TCPXO experience in GKE Phase 1

This change include support for improving user experience to enable TCPX for A3 machine. It cover:
- deploy Kubernetes network setup for multi-vpc
- deploy NCCL and NRI daemonset
- Script for injecting rxdm sidecar into user workload
- Deploy the updated user workload job to cluster